### PR TITLE
Add gen_coap, an Erlang CoAP implementation.

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -119,6 +119,12 @@ title: Implementations
           
           <p><a class="btn" href="http://www.coapsharp.com/">View details &raquo;</a></p>
           
+          <h3 id="erlang">Erlang</h3>
+          
+          <p><strong>gen_coap</strong> is a pure Erlang implementation of a generic CoAP client and server:</p>
+          
+          <p><a class="btn" href="https://github.com/gotthardp/gen_coap">View details &raquo;</a></p>
+          
           <h3 id="go">Go</h3>
           
           <p><a class="btn" href="https://github.com/dustin/go-coap">View details &raquo;</a></p>


### PR DESCRIPTION
I believe the implementations are listed in an alphabetical order (except the Java), so I added "E"-rlang before "G"-o.