### PR TITLE
Add lobaro-coap-go implementation

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -148,7 +148,14 @@ title: Implementations
           <p><a class="btn" href="https://github.com/gotthardp/gen_coap">View details &raquo;</a></p>
           
           <h3 id="go">Go</h3>
-          
+
+          <p><strong>lobaro-coap-go</strong> is a client and server library for
+            CoAP in Go based on the lobaro-coap C implementation.</p>
+
+          <p><a class="btn" href="http://www.lobaro.com/lobaro-coap/">View details &raquo;</a></p>
+
+          <p><strong>go-coap</strong> Implementation of CoAP in go.</p>
+
           <p><a class="btn" href="https://github.com/dustin/go-coap">View details &raquo;</a></p>
           
           <h3 id="javascript-nodejs">JavaScript (node.js)</h3>


### PR DESCRIPTION
We finished the first version of the Lobaro CoAP Go implementation and like to also mention it on coap.technology

The implementation allows a simple interface to test lobaro-coap on Windows and Linux and we started to build a Lobaro CoAP based UDP Server. The goal is to have an API similar to the Go http package future.