### PR TITLE
Update public services

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -25,11 +25,6 @@ title: Tools
           <p>
             <a class='btn' href='http://coap.me'>View details &raquo;</a>
           </p>
-          <p>
-            Additional resources are available at
-            <a href='http://vs0.inf.ethz.ch'>vs0.inf.ethz.ch</a>
-            including DTLS support.
-          </p>
           <h3>Wireshark dissector</h3>
           <p>
             A protocol dissector for CoAP has been part of

--- a/tools.html
+++ b/tools.html
@@ -25,6 +25,20 @@ title: Tools
           <p>
             <a class='btn' href='http://coap.me'>View details &raquo;</a>
           </p>
+          <h4>
+            <a href='https://coaprd.com/'>coaprd.com</a>
+          </h4>
+          <p>
+            An open experimental public resource directory.
+          </p>
+          <h4>
+            <a href='https://coap.amsuess.com/'>A collection of online CoAP tools</a>
+          </h4>
+          <p>
+            Several experimental open public CoAP tools:
+            a cross proxy, a resource directory, and a demo server.
+            The demo server supports EDHOC.
+          </p>
           <h3>Wireshark dissector</h3>
           <p>
             A protocol dissector for CoAP has been part of

--- a/tools.html
+++ b/tools.html
@@ -11,9 +11,12 @@ title: Tools
       <hr>
       <div class='row-fluid'>
         <div class='span4'>
-          <h2>
+          <h3>
+            Public CoAP services
+          </h3>
+          <h4>
             <a href='http://coap.me'>coap.me</a>
-          </h2>
+          </h4>
           <p>
             Access CoAP nodes via HTTP, analyze pcaps (tcpdump/wireshark packet capture files)
             and run the ETSI interoperability tests against your server on


### PR DESCRIPTION
As @cabo asked me whether I can say anything about coaprd.com to describe it here, this is adding it.

I'm also taking the liberty to plug my own public server in the same PR.

The items are grouped together through a common heading, which is set to the appropriate level under the full-page "Tools" heading (which is an h2). [edit] The outdated ethz server is removed from that group.