### PR TITLE
Wireshark: Remove history

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -41,12 +41,8 @@ title: Tools
           </p>
           <h3>Wireshark dissector</h3>
           <p>
-            A protocol dissector for CoAP has been part of
-            <a href='http://www.wireshark.org'>Wireshark</a>
-            for quite some time, supporting the development of CoAP.
-            The final CoAP protocol is supported by Wireshark 1.12, the
-            <a href='http://www.wireshark.org/download.html'>stable version</a>
-            of Wireshark.
+            A protocol dissector for CoAP is available in
+            <a href='http://www.wireshark.org'>Wireshark</a>.
           </p>
           <h3>crosscoap</h3>
           <p>


### PR DESCRIPTION
This removes references to pre-RFC versions of CoAP from the last place on the website, along with mentioning an ancient version of Wireshark. For anyone coming across this now, what is relevant is that Wireshark just supports it.

(One might explicitly mention OSCORE support, but that hasn't made it to this website as a whole yet, cf. https://github.com/coap-technology/coap-technology.github.io/pull/18 and https://github.com/coap-technology/coap-technology.github.io/pull/32 and https://github.com/coap-technology/coap-technology.github.io/pull/33)